### PR TITLE
Add WordPress coding standards linting

### DIFF
--- a/.config/windows-install-php-composer.bat
+++ b/.config/windows-install-php-composer.bat
@@ -1,0 +1,98 @@
+@REM Install PHP and Composer on Windows
+@REM
+@REM Usage:
+@REM   install-php.bat [version] [arch] [dir]
+@REM
+@REM   version: PHP version to install (default: 8.1.21)
+@REM   arch:    Architecture to install (default: x64)
+@REM   dir:     Directory to install to (default: C:\php)
+@REM
+@REM Examples:
+@REM   install-php.bat
+@REM   install-php.bat 8.1.21
+@REM   install-php.bat 8.1.21 x64
+@REM   install-php.bat 8.1.21 x64 C:\php
+@REM
+
+@ECHO OFF
+
+SET PHP_VERSION=%1
+SET PHP_ARCH=%2
+SET PHP_DIR=%3
+
+IF "%PHP_VERSION%" == "" SET PHP_VERSION=8.1.21
+IF "%PHP_ARCH%" == "" SET PHP_ARCH=x64
+IF "%PHP_DIR%" == "" SET PHP_DIR=C:\php
+
+SET PHP_ZIP=php-%PHP_VERSION%-nts-Win32-vs16-%PHP_ARCH%.zip
+SET PHP_URL=https://windows.php.net/downloads/releases/%PHP_ZIP%
+
+SET PHP_EXE=%PHP_DIR%\php.exe
+
+IF EXIST "%PHP_EXE%" (
+    ECHO PHP already installed at %PHP_DIR%
+    GOTO install_composer
+)
+
+ECHO Installing PHP %PHP_VERSION% %PHP_ARCH% to %PHP_DIR%
+
+IF NOT EXIST "%PHP_DIR%" (
+    MKDIR "%PHP_DIR%"
+)
+
+IF NOT EXIST "%PHP_DIR%" (
+    ECHO Failed to create directory %PHP_DIR%
+    EXIT /B 1
+)
+
+IF NOT EXIST "%PHP_ZIP%" (
+    ECHO Downloading %PHP_URL%
+    IF NOT EXIST "%PHP_ZIP%" (
+        powershell -Command "(New-Object Net.WebClient).DownloadFile('%PHP_URL%', '%PHP_ZIP%')"
+    )
+)
+
+IF NOT EXIST "%PHP_ZIP%" (
+    ECHO Failed to download %PHP_URL%
+    EXIT /B 1
+)
+
+ECHO Extracting %PHP_ZIP%
+powershell -Command "Expand-Archive -Path '%PHP_ZIP%' -DestinationPath '%PHP_DIR%'"
+
+IF NOT EXIST "%PHP_EXE%" (
+    ECHO Failed to extract %PHP_ZIP%
+    EXIT /B 1
+)
+
+ECHO PHP %PHP_VERSION% %PHP_ARCH% installed to %PHP_DIR%
+
+@REM Install Composer package manager for PHP.
+:install_composer
+
+SET COMPOSER_EXE=%PHP_DIR%\composer.phar
+IF EXIST "%COMPOSER_EXE%" (
+    ECHO Composer already installed at %COMPOSER_EXE%
+    EXIT /B 0
+)
+
+SET "EXPECTED_CHECKSUM="
+FOR /f "usebackq delims=" %%a IN (`php -r "copy('https://composer.github.io/installer.sig', 'php://stdout');"`) DO SET "EXPECTED_CHECKSUM=%%a"
+
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+SET "ACTUAL_CHECKSUM="
+FOR /f "usebackq delims=" %%a IN (`certutil -hashfile composer-setup.php SHA384 ^| findstr /i /v "certutil"`) DO SET "ACTUAL_CHECKSUM=%%a"
+
+if not "%EXPECTED_CHECKSUM%" == "%ACTUAL_CHECKSUM%" (
+    ECHO ERROR: Invalid installer checksum
+    ECHO EXPECTED: %EXPECTED_CHECKSUM%
+    ECHO ACTUAL: %ACTUAL_CHECKSUM%
+    DEL composer-setup.php
+    EXIT /b 1
+)
+
+php composer-setup.php --quiet
+SET "RESULT=%errorlevel%"
+DEL composer-setup.php
+ECHO Composer installed to %COMPOSER_EXE%
+EXIT /b %RESULT%

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
 		"johnbillion.vscode-wordpress-hooks",
 		"bmewburn.vscode-intelephense-client",
 		"m1guelpf.better-pest",
-		"esbenp.prettier-vscode"
+		"esbenp.prettier-vscode",
+		"obliviousharmony.vscode-php-codesniffer"
 	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,10 @@
 	"editor.formatOnPaste": false,
 	"prettier.configPath": ".prettierrc.json",
 	"prettier.useEditorConfig": false,
+	"phpCodeSniffer.autoExecutable": true,
+	"phpCodeSniffer.exclude": [ "**/vendor/**", "**/node_modules/**" ],
+	"phpCodeSniffer.standard": "Custom",
+	"phpCodeSniffer.standardCustom": "phpcs.xml.dist",
 	"intelephense.stubs": [
 		"apache",
 		"bcmath",

--- a/composer.json
+++ b/composer.json
@@ -4,14 +4,9 @@
 	"type": "project",
 	"scripts": {
 		"test": "./vendor/bin/pest",
-		"phpcs": "phpcs --standard=phpcs.xml.dist",
-		"phpcbf": "phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
-		"format": "@phpcbf --filter=gitmodified",
-		"format:all": "@phpcbf",
-		"lint": "@phpcs --filter=gitmodified",
-		"lint:errors": "@phpcs -n --filter=gitmodified",
-		"lint:all": "@phpcs -n",
-		"lint:all-errors": "@phpcs -n"
+		"lint": "phpcs --standard=phpcs.xml.dist",
+		"lint:fix": "phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
+		"lint:errors": "@phpcs -n"
 	},
 	"license": "GPL-2.0+",
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,15 @@
 	"description": "A fork of the Twenty Twenty-Three WordPress theme to demonstrate how to provide a portable development environment for a theme.",
 	"type": "project",
 	"scripts": {
-		"test": "./vendor/bin/pest"
+		"test": "./vendor/bin/pest",
+		"phpcs": "phpcs --standard=phpcs.xml.dist",
+		"phpcbf": "phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
+		"format": "@phpcbf --filter=gitmodified",
+		"format:all": "@phpcbf",
+		"lint": "@phpcs --filter=gitmodified",
+		"lint:errors": "@phpcs -n --filter=gitmodified",
+		"lint:all": "@phpcs -n",
+		"lint:all-errors": "@phpcs -n"
 	},
 	"license": "GPL-2.0+",
 	"autoload": {
@@ -21,14 +29,17 @@
 	],
 	"config": {
 		"optimize-autoloader": true,
-		"classmap-authoritative": true,
 		"preferred-install": "dist",
 		"sort-packages": true,
 		"allow-plugins": {
-			"pestphp/pest-plugin": true
+			"pestphp/pest-plugin": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	},
 	"require-dev": {
+		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+		"squizlabs/php_codesniffer": "3.*",
+		"wp-coding-standards/wpcs": "dev-develop",
 		"pestphp/pest": "^2.8"
 	},
 	"minimum-stability": "stable",

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
 		"optimize-autoloader": true,
 		"preferred-install": "dist",
 		"sort-packages": true,
+		"bin-compat": "full",
 		"allow-plugins": {
 			"pestphp/pest-plugin": true,
 			"dealerdirect/phpcodesniffer-composer-installer": true
@@ -33,9 +34,9 @@
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-		"squizlabs/php_codesniffer": "3.*",
-		"wp-coding-standards/wpcs": "dev-develop",
-		"pestphp/pest": "^2.8"
+		"pestphp/pest": "^2.8",
+		"squizlabs/php_codesniffer": "^3.7",
+		"wp-coding-standards/wpcs": "dev-develop"
 	},
 	"minimum-stability": "stable",
 	"prefer-stable": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f7335571a0a60a3b1f8a9197dd685c4a",
+    "content-hash": "0c00c84ba0ad9107dacb7f907424389d",
     "packages": [],
     "packages-dev": [
         {
@@ -101,6 +101,84 @@
                 }
             ],
             "time": "2023-06-22T14:22:36+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "time": "2023-01-05T11:28:13+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -979,6 +1057,142 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "029af41e270ae73f10c0e9a1ce376b12da4e4810"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/029af41e270ae73f10c0e9a1ce376b12da4e4810",
+                "reference": "029af41e270ae73f10c0e9a1ce376b12da4e4810",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0.6",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "time": "2023-06-17T22:57:40+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "ba259eaaefac118648e1263919b9530667ffcf01"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/ba259eaaefac118648e1263919b9530667ffcf01",
+                "reference": "ba259eaaefac118648e1263919b9530667ffcf01",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.7.1 || 4.0.x-dev@dev"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.0.5"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "time": "2023-05-27T13:39:12+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2630,6 +2844,63 @@
             "time": "2023-02-07T11:34:05+00:00"
         },
         {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2023-02-22T23:07:41+00:00"
+        },
+        {
             "name": "symfony/console",
             "version": "v6.3.0",
             "source": {
@@ -3575,11 +3846,70 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
             "time": "2022-06-03T18:03:27+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "dev-develop",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "7777c683c61bf162ecadc9ea7e58f418c96fb13d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7777c683c61bf162ecadc9ea7e58f418c96fb13d",
+                "reference": "7777c683c61bf162ecadc9ea7e58f418c96fb13d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": ">=5.4",
+                "phpcsstandards/phpcsextra": "^1.0",
+                "phpcsstandards/phpcsutils": "^1.0.5",
+                "squizlabs/php_codesniffer": "^3.7.2"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "ext-mbstring": "For improved results"
+            },
+            "default-branch": true,
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "time": "2023-07-06T10:10:04+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "wp-coding-standards/wpcs": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c00c84ba0ad9107dacb7f907424389d",
+    "content-hash": "d7808740c8d58359ad3bdb407f8a7433",
     "packages": [],
     "packages-dev": [
         {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -27,7 +27,6 @@
 	</rule>
 	<rule ref="Squiz.Commenting.FileComment.Missing">
 		<exclude-pattern>tests/*</exclude-pattern>
-		<exclude-pattern>**/*.min.asset.php</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.Commenting.ClassComment.Missing">
 		<exclude-pattern>tests/*</exclude-pattern>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,7 +5,7 @@
 	<rule ref="WordPress-Core"/>
 	<rule ref="WordPress-Docs"/>
 	<rule ref="WordPress.WP.I18n"/>
-	<config name="text_domain" value="wordpress-theme"/>
+	<config name="text_domain" value="wordpresstheme"/>
 	<file>./.config</file>
 	<file>./parts</file>
 	<file>./patterns</file>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="WordPress Coding Standards for WordPress Theme">
-	<description>Sniffs for WordPress plugins and themes, with minor modifications for this theme</description>
+	<description>Code standards for WordPress plugins and themes, with minor modifications for this theme</description>
 
 	<rule ref="WordPress-Core"/>
 	<rule ref="WordPress-Docs"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards for WordPress Theme">
+	<description>Sniffs for WordPress plugins and themes, with minor modifications for this theme</description>
+
+	<rule ref="WordPress-Core"/>
+	<rule ref="WordPress-Docs"/>
+	<rule ref="WordPress.WP.I18n"/>
+	<config name="text_domain" value="wordpress-theme"/>
+	<file>./.config</file>
+	<file>./parts</file>
+	<file>./patterns</file>
+	<file>./src</file>
+	<file>./styles</file>
+	<file>./templates</file>
+	<file>./tests</file>
+	<file>./style.css</file>
+
+	<!-- Exclude generated files -->
+	<exclude-pattern>node_modules/*</exclude-pattern>
+
+	<!-- Exclude third party libraries -->
+	<exclude-pattern>./vendor/*</exclude-pattern>
+
+	<!-- Do not require docblocks for unit tests -->
+	<rule ref="Squiz.Commenting.FunctionComment.Missing">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.FileComment.Missing">
+		<exclude-pattern>tests/*</exclude-pattern>
+		<exclude-pattern>**/*.min.asset.php</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.ClassComment.Missing">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.ClassComment.SpacingAfter">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.FunctionComment.MissingParamTag">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="Generic.Commenting.DocComment.Empty">
+    	<exclude-pattern>tests/*</exclude-pattern>
+    </rule>
+	<rule ref="Generic.Commenting.DocComment.MissingShort">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.VariableComment.Missing">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.FunctionCommentThrowTag.Missing">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+
+	<!-- Ignore filename error -->
+	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
+		<exclude-pattern>/tests/*</exclude-pattern>
+	</rule>
+
+	<!-- Exclude php tests from file and class name sniffs (for Core parity). -->
+	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
+		<exclude-pattern>/tests/*</exclude-pattern>
+	</rule>
+	<rule ref="PEAR.NamingConventions.ValidClassName.Invalid">
+		<exclude-pattern>/tests/*</exclude-pattern>
+	</rule>
+</ruleset>


### PR DESCRIPTION
### What's being changed

This pull request adds the Composer package for PHP Codesniffer, WordPress coding standards rules, and a custom ruleset file for checking code against WordPress coding standards. It also includes VS Code configurations so `phpcs` will run on open files without needing to use the command line to check code quality.
