### PR TITLE
Add lint workflow file to check files in a pull request using WordPress coding standards

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,0 +1,28 @@
+name: PHP CodeSniffer
+
+on:
+    pull_request:
+        paths:
+            - '**.php'
+            - '**.js'
+            - '**.css'
+            - '**.html'
+
+jobs:
+    phpcs:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.1'
+
+            - name: Install Composer dependencies
+              run: composer install --no-progress --no-suggest
+
+            - name: Run PHP CodeSniffer
+              run: vendor/bin/phpcs --standard=phpcs.xml.dist --ignore=*/vendor/*,*/node_modules/* .

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -39,4 +39,4 @@ jobs:
               run: composer install --no-progress --prefer-dist --no-interaction --no-autoloader
 
             - name: Run PHP CodeSniffer
-              run: vendor/bin/phpcs --standard=phpcs.xml.dist --ignore=*/vendor/*,*/node_modules/* ${{ steps.changed-files.outputs.changed_files }}
+              run: echo ${{ steps.changed-files.outputs.changed_files }} | vendor/bin/phpcs --standard=phpcs.xml.dist --ignore=*/vendor/*,*/node_modules/* {} \;

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -19,9 +19,6 @@ jobs:
               with:
                   fetch-depth: 2
 
-            - name: Get changes
-              run: git diff --name-only -r HEAD^1 HEAD
-
             - name: Cache Composer dependencies
               uses: actions/cache@v2
               with:
@@ -39,4 +36,4 @@ jobs:
               run: composer install --no-progress --prefer-dist --no-interaction --no-autoloader
 
             - name: Run PHP CodeSniffer
-              run: echo ${{ steps.changed-files.outputs.changed_files }} | vendor/bin/phpcs --standard=phpcs.xml.dist --ignore=*/vendor/*,*/node_modules/* {} \;
+              run: git diff --name-only -r HEAD^1 HEAD | vendor/bin/phpcs --standard=phpcs.xml.dist --ignore=*/vendor/*,*/node_modules/* {} \;

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -35,5 +35,8 @@ jobs:
             - name: Install Composer dependencies
               run: composer install --no-progress --prefer-dist --no-interaction --no-autoloader
 
+            - name: List changed files
+              run: git diff --name-only -r HEAD^1 HEAD
+
             - name: Run PHP CodeSniffer
-              run: git diff --name-only -r HEAD^1 HEAD | vendor/bin/phpcs --standard=phpcs.xml.dist --ignore=*/vendor/*,*/node_modules/* {} \;
+              run: git diff --name-only -r HEAD^1 HEAD | vendor/bin/phpcs --standard=phpcs.xml.dist --ignore=*/vendor/*,*/node_modules/* {} ';'

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -7,6 +7,7 @@ on:
             - '**.js'
             - '**.css'
             - '**.html'
+            - '.github/workflows/phpcs.yml'
 
 jobs:
     phpcs:

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -42,26 +42,16 @@ jobs:
 
             - name: Create PHP CodeSniffer Summary
               id: phpcs
-              run: |
-                  vendor/bin/phpcs --report-file=phpcs_summary.txt --file-list=changed_files.txt --basepath=. --standard=phpcs.xml.dist --report-width=120 --report=summary -q -w
+              run: vendor/bin/phpcs --report-file=phpcs_summary.txt --file-list=changed_files.txt --basepath=. --standard=phpcs.xml.dist --report-width=120 --report=summary -q -w
               continue-on-error: true
 
             - name: Create PHP CodeSniffer Body
-              run: vendor/bin/phpcs --report-file=phpcs_body.txt --file-list=changed_files.txt --standard=phpcs.xml.dist --report-width=120 --report=code -q -w -s
               if: ${{ steps.phpcs.outputs.exit_code != 0 }}
+              run: vendor/bin/phpcs --report-file=phpcs_body.txt --file-list=changed_files.txt --standard=phpcs.xml.dist --report-width=120 --report=code -q -w -s
               continue-on-error: true
 
-            - name: Create pull request review
-              uses: actions/github@v4
+            - name: Show PHP CodeSniffer Output
               if: ${{ steps.phpcs.outputs.exit_code != 0 }}
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
-                  repository: ${{ github.repository }}
-                  pull_request_number: ${{ github.event.pull_request.number }}
-                  event_type: pull_request_review
-                  body: |
-                      PHP CodeSniffer found the following issues. See the comments below for more details.
-                      ```
-                      $(cat phpcs_summary.txt)
-                      ```
-                  comments: $(cat phpcs_body.txt)
+              run: |
+                  cat phpcs_summary.txt
+                  cat phpcs_body.txt

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -47,7 +47,7 @@ jobs:
               continue-on-error: true
 
             - name: Create PHP CodeSniffer Body
-                  vendor/bin/phpcs --report-file=phpcs_body.txt --file-list=changed_files.txt --standard=phpcs.xml.dist --report-width=120 --report=code -q -w -s
+              run: vendor/bin/phpcs --report-file=phpcs_body.txt --file-list=changed_files.txt --standard=phpcs.xml.dist --report-width=120 --report=code -q -w -s
               if: ${{ steps.phpcs.outputs.exit_code != 0 }}
               continue-on-error: true
 

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -25,5 +25,9 @@ jobs:
             - name: Install Composer dependencies
               run: composer install --no-progress --no-suggest
 
+            - name: Get changed files
+              id: changes
+              run: echo "::set-output name=files::$(git diff --name-only HEAD $(git merge-base HEAD ${{ github.event.pull_request.base.sha }}))"
+
             - name: Run PHP CodeSniffer
-              run: vendor/bin/phpcs --standard=phpcs.xml.dist --ignore=*/vendor/*,*/node_modules/* .
+              run: vendor/bin/phpcs --standard=phpcs.xml.dist --ignore=*/vendor/*,*/node_modules/* ${{ steps.changes.outputs.files }}

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -40,5 +40,28 @@ jobs:
                   git diff --name-only -r HEAD^1 HEAD > changed_files.txt
                   cat changed_files.txt
 
-            - name: Run PHP CodeSniffer
-              run: vendor/bin/phpcs --standard=phpcs.xml.dist --ignore=*/vendor/*,*/node_modules/* --file-list=changed_files.txt
+            - name: Create PHP CodeSniffer Summary
+              id: phpcs
+              run: |
+                  vendor/bin/phpcs --report-file=phpcs_summary.txt --file-list=changed_files.txt --basepath=. --standard=phpcs.xml.dist --report-width=120 --report=summary -q -w
+              continue-on-error: true
+
+            - name: Create PHP CodeSniffer Body
+                  vendor/bin/phpcs --report-file=phpcs_body.txt --file-list=changed_files.txt --standard=phpcs.xml.dist --report-width=120 --report=code -q -w -s
+              if: ${{ steps.phpcs.outputs.exit_code != 0 }}
+              continue-on-error: true
+
+            - name: Create pull request review
+              uses: actions/github@v4
+              if: ${{ steps.phpcs.outputs.exit_code != 0 }}
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  repository: ${{ github.repository }}
+                  pull_request_number: ${{ github.event.pull_request.number }}
+                  event_type: pull_request_review
+                  body: |
+                      PHP CodeSniffer found the following issues. See the comments below for more details.
+                      ```
+                      $(cat phpcs_summary.txt)
+                      ```
+                  comments: $(cat phpcs_body.txt)

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -25,9 +25,5 @@ jobs:
             - name: Install Composer dependencies
               run: composer install --no-progress --prefer-dist --no-interaction --no-autoloader
 
-            - name: Get changed files
-              id: changes
-              run: echo "::set-output name=files::$(git diff --name-only HEAD $(git merge-base HEAD ${{ github.event.pull_request.base.sha }}))"
-
             - name: Run PHP CodeSniffer
-              run: vendor/bin/phpcs --standard=phpcs.xml.dist --ignore=*/vendor/*,*/node_modules/* ${{ steps.changes.outputs.files }}
+              run: git diff --name-only HEAD $(git merge-base HEAD ${{ github.event.pull_request.base.sha }}) | vendor/bin/phpcs --standard=phpcs.xml.dist --ignore=*/vendor/*,*/node_modules/*

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -36,7 +36,7 @@ jobs:
               run: composer install --no-progress --prefer-dist --no-interaction --no-autoloader
 
             - name: List changed files
-              run: git diff --name-only -r HEAD^1 HEAD
+              run: git diff --name-only -r HEAD^1 HEAD > changed_files.txt
 
             - name: Run PHP CodeSniffer
-              run: git diff --name-only -r HEAD^1 HEAD | vendor/bin/phpcs --standard=phpcs.xml.dist --ignore=*/vendor/*,*/node_modules/* {} ';'
+              run: vendor/bin/phpcs --standard=phpcs.xml.dist --ignore=*/vendor/*,*/node_modules/* --file-list=changed_files.txt

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -15,7 +15,12 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
+              with:
+                  fetch-depth: 2
+
+            - name: Get changes
+              run: git diff --name-only -r HEAD^1 HEAD
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -26,4 +31,4 @@ jobs:
               run: composer install --no-progress --prefer-dist --no-interaction --no-autoloader
 
             - name: Run PHP CodeSniffer
-              run: git diff --name-only HEAD $(git merge-base HEAD ${{ github.event.pull_request.base.sha }}) | vendor/bin/phpcs --standard=phpcs.xml.dist --ignore=*/vendor/*,*/node_modules/*
+              run: vendor/bin/phpcs --standard=phpcs.xml.dist --ignore=*/vendor/*,*/node_modules/* ${{ steps.changed-files.outputs.changed_files }}

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -36,7 +36,9 @@ jobs:
               run: composer install --no-progress --prefer-dist --no-interaction --no-autoloader
 
             - name: List changed files
-              run: git diff --name-only -r HEAD^1 HEAD > changed_files.txt
+              run: |
+                  git diff --name-only -r HEAD^1 HEAD > changed_files.txt
+                  cat changed_files.txt
 
             - name: Run PHP CodeSniffer
               run: vendor/bin/phpcs --standard=phpcs.xml.dist --ignore=*/vendor/*,*/node_modules/* --file-list=changed_files.txt

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -23,7 +23,7 @@ jobs:
                   php-version: '8.1'
 
             - name: Install Composer dependencies
-              run: composer install --no-progress --prefer-dist --optimize-autoloader --no-interaction -- dealerdirect/phpcodesniffer-composer-installer squizlabs/php_codesniffer wp-coding-standards/wpcs
+              run: composer install --no-progress --prefer-dist --no-interaction --no-autoloader
 
             - name: Get changed files
               id: changes

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -23,7 +23,7 @@ jobs:
                   php-version: '8.1'
 
             - name: Install Composer dependencies
-              run: composer install --no-progress --no-suggest
+              run: composer install --no-progress --prefer-dist --optimize-autoloader --no-interaction -- dealerdirect/phpcodesniffer-composer-installer squizlabs/php_codesniffer wp-coding-standards/wpcs
 
             - name: Get changed files
               id: changes

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -22,10 +22,18 @@ jobs:
             - name: Get changes
               run: git diff --name-only -r HEAD^1 HEAD
 
+            - name: Cache Composer dependencies
+              uses: actions/cache@v2
+              with:
+                  path: vendor
+                  key: composer-${{ hashFiles('composer.lock') }}
+                  restore-keys: composer-
+
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
                   php-version: '8.1'
+                  extensions: mbstring, zip
 
             - name: Install Composer dependencies
               run: composer install --no-progress --prefer-dist --no-interaction --no-autoloader

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,7 +9,6 @@
 	<file>./.config</file>
 	<file>./parts</file>
 	<file>./patterns</file>
-	<file>./src</file>
 	<file>./styles</file>
 	<file>./templates</file>
 	<file>./tests</file>


### PR DESCRIPTION
### What's being changed

This pull request adds a workflow file that uses PHP Codesniffer and WordPress coding standards to check our codebase for code quality. It only checks the files a pull request modifies and will output the report text in the run's stdout.