### PR TITLE
Move PHP CodeSniffer configuration file to .config folder

### DIFF
--- a/.config/.phpcs.xml.dist
+++ b/.config/.phpcs.xml.dist
@@ -3,17 +3,18 @@
 	<description>Generally-applicable sniffs for WordPress code.</description>
 
 	<!-- What to scan -->
-	<file>.</file>
-	<exclude-pattern>/test/phpunit/wp-config.php</exclude-pattern>
-	<exclude-pattern>/test/phpunit/bootstrap.php</exclude-pattern>
-	<exclude-pattern>/vendor/</exclude-pattern>
-	<exclude-pattern>/node_modules/</exclude-pattern>
+	<file>../</file>
+	<exclude-pattern>../test/phpunit/wp-config.php</exclude-pattern>
+	<exclude-pattern>../test/phpunit/bootstrap.php</exclude-pattern>
+	<exclude-pattern>../vendor/</exclude-pattern>
+	<exclude-pattern>../node_modules/</exclude-pattern>
+	<exclude-pattern>../wordpress/</exclude-pattern>
 
 	<!-- How to scan -->
 	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
 	<!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
 	<arg value="sp"/><!-- Show sniff and progress -->
-	<arg name="basepath" value="./"/><!-- Strip the file paths down to the relevant bit -->
+	<arg name="basepath" value="../"/><!-- Strip the file paths down to the relevant bit -->
 	<arg name="colors"/>
 	<arg name="extensions" value="php"/>
 	<arg name="parallel" value="8"/><!-- Enables parallel processing when available for faster results. -->
@@ -24,7 +25,6 @@
 	<config name="minimum_supported_wp_version" value="4.6"/>
 	<rule ref="WordPress"/>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
-	    <exclude-pattern>/test/phpunit/*.php</exclude-pattern>
 		<properties>
 			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->
 			<property name="prefixes" type="array" value="wordpress_theme"/>
@@ -44,43 +44,43 @@
 
 	<!-- Do not require docblocks for unit tests -->
 	<rule ref="Squiz.Commenting.FunctionComment.Missing">
-		<exclude-pattern>test/*</exclude-pattern>
+		<exclude-pattern>../test/*</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.Commenting.FileComment.Missing">
-		<exclude-pattern>test/*</exclude-pattern>
+		<exclude-pattern>../test/*</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.Commenting.ClassComment.Missing">
-		<exclude-pattern>test/*</exclude-pattern>
+		<exclude-pattern>../test/*</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.Commenting.ClassComment.SpacingAfter">
-		<exclude-pattern>test/*</exclude-pattern>
+		<exclude-pattern>../test/*</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.Commenting.FunctionComment.MissingParamTag">
-		<exclude-pattern>test/*</exclude-pattern>
+		<exclude-pattern>../test/*</exclude-pattern>
 	</rule>
 	<rule ref="Generic.Commenting.DocComment.Empty">
-    	<exclude-pattern>test/*</exclude-pattern>
+    	<exclude-pattern>../test/*</exclude-pattern>
     </rule>
 	<rule ref="Generic.Commenting.DocComment.MissingShort">
-		<exclude-pattern>test/*</exclude-pattern>
+		<exclude-pattern>../test/*</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.Commenting.VariableComment.Missing">
-		<exclude-pattern>test/*</exclude-pattern>
+		<exclude-pattern>../test/*</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.Commenting.FunctionCommentThrowTag.Missing">
-		<exclude-pattern>test/*</exclude-pattern>
+		<exclude-pattern>../test/*</exclude-pattern>
 	</rule>
 
 	<!-- Ignore filename error -->
 	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
-		<exclude-pattern>test/*</exclude-pattern>
+		<exclude-pattern>../test/*</exclude-pattern>
 	</rule>
 
 	<!-- Exclude php tests from file and class name sniffs (for Core parity). -->
 	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
-		<exclude-pattern>test/*</exclude-pattern>
+		<exclude-pattern>../test/*</exclude-pattern>
 	</rule>
 	<rule ref="PEAR.NamingConventions.ValidClassName.Invalid">
-		<exclude-pattern>test/*</exclude-pattern>
+		<exclude-pattern>../test/*</exclude-pattern>
 	</rule>
 </ruleset>

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
 	"phpCodeSniffer.autoExecutable": true,
 	"phpCodeSniffer.exclude": [ "**/vendor/**", "**/node_modules/**" ],
 	"phpCodeSniffer.standard": "Custom",
-	"phpCodeSniffer.standardCustom": ".phpcs.xml.dist",
+	"phpCodeSniffer.standardCustom": ".config/.phpcs.xml.dist",
 	"intelephense.diagnostics.run": "onSave",
 	"intelephense.environment.phpVersion": "8.1.0",
 	"intelephense.format.enable": false,

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
 			"@putenv WP_SQLITE_MODE=enabled",
 			"./vendor/bin/phpunit"
 		],
-		"lint": "phpcs --standard=.phpcs.xml.dist --report-full --report-summary --basepath=.",
-		"lint:fix": "phpcbf --standard=.phpcs.xml.dist --report-summary --basepath=.",
+		"lint": "phpcs --standard=.config/.phpcs.xml.dist --report-full --report-summary",
+		"lint:fix": "phpcbf --standard=.config/.phpcs.xml.dist --report-summary",
 		"lint:errors": "@phpcs -n"
 	},
 	"license": "GPL-2.0+",


### PR DESCRIPTION
This pull request moves the PHP CodeSniffer configuration file from the project's root directory to the .config folder.